### PR TITLE
Masamitsu

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,7 @@ ul {
 }
 
 body{
+	padding-top:150px;
 }
 
 .navbar-nav > li > a {

--- a/app/controllers/admins/order_products_controller.rb
+++ b/app/controllers/admins/order_products_controller.rb
@@ -1,7 +1,23 @@
 class Admins::OrderProductsController < ApplicationController
 	before_action :authenticate_admin!
+  	def update
+  		order_product=OrderProduct.find(params[:id])
+  		order_product.update(order_product_params)
+  		order=Order.find(order_product.order_id)
+  		order_products=order.order_products.pluck(:product_status)
 
-  #こっちのアクションは使わない？
-  def update
-  end
+  		if order_products.all?{|f| f == "Made"}
+  			order.update(order_status: 3)
+
+  		elsif params[:order_product][:product_status] == 'In_production'
+  			order.update(order_status: 2)
+  		end
+  		redirect_to admins_order_path(order)
+  	end
+
+  	private
+
+  	def order_product_params
+    	params.require(:order_product).permit(:product_status)
+  	end
 end

--- a/app/controllers/admins/orders_controller.rb
+++ b/app/controllers/admins/orders_controller.rb
@@ -12,17 +12,20 @@ class Admins::OrdersController < ApplicationController
   end
 
   def update
-    @order = Order.find(params[:id])
+    order = Order.find(params[:id])
 
     #以下、文字列で値を取得する...
-    @order_str = params[:order][:order_status]
+    order_str = params[:order][:order_status]
     #@product_str = @order.find(id: [:order][:id][:product_status])
-    @product_str = params[:order][:order_products_attributes][:product_status]
+    #@product_str = params[:order][:order_products_attributes][:product_status]
 
+    products=order.order_products
+    #binding.pry
+    if order_str == "Payment_confirmation"
+    products.update_all(product_status: 1)
+    end
 
-
-    binding.pry
-    @order.update(order_params)
+    order.update(order_params)
     redirect_to admins_order_path
   end
 
@@ -30,8 +33,8 @@ class Admins::OrdersController < ApplicationController
 
   def order_params
     params.require(:order).permit(
-      :created_at, :postal_code, :address, :name, :shipping, :payment_method, :order_status,
-      order_products_attributes: [:id, :product_id, :order_id, :quantity, :price_with_tax, :product_status]
+      :created_at, :postal_code, :address, :name, :shipping, :payment_method, :order_status
       )
   end
+
 end

--- a/app/controllers/customers/orders_controller.rb
+++ b/app/controllers/customers/orders_controller.rb
@@ -4,7 +4,11 @@ class Customers::OrdersController < ApplicationController
 
 
   def new
+    if current_customer.cart_products == []
+      redirect_to cart_products_path
+    else
     @order = Order.new
+  end
   end
 
   def create
@@ -45,7 +49,7 @@ class Customers::OrdersController < ApplicationController
         order_product.order_id = @order.id
         order_product.product_id = cart_puroduct.product_id
         order_product.quantity = cart_puroduct.quantity
-        order_product.price_with_tax = cart_puroduct.product.price*11/10
+        order_product.price_with_tax = cart_puroduct.product.price*11/10.floor
         order_product.save
         #order_productに情報を移したらcart_puroductは消去
         cart_puroduct.destroy
@@ -59,7 +63,6 @@ class Customers::OrdersController < ApplicationController
 
   def index
     @orders = @customer.orders
-    binding.pry
   end
 
   def show
@@ -94,16 +97,22 @@ class Customers::OrdersController < ApplicationController
         #new view プルダウン部で定義したselect_to_addressより値を取得
         #登録済み住所の情報取得メソッド...要動作確認
         @sta = params[:order][:send_to_address].to_i
+        unless @sta == 0
         @send_to_address = Destination.find(@sta)
         @order.postal_code = @send_to_address.postal_code
         @order.address = @send_to_address.address
         @order.name = @send_to_address.name
+        end
       when 3
         #新規発送先
         #:new_add→new viewにて定義
         @order.postal_code = params[:order][:new_add][:postal_code]
         @order.address = params[:order][:new_add][:address]
         @order.name = params[:order][:new_add][:name]
+    end
+    if @order.postal_code == "" || @order.address == "" || @sta == 0
+      redirect_to new_order_path
+      flash[:danger] = '!!! 未入力項目があります !!!'
     end
   end
 

--- a/app/controllers/customers/orders_controller.rb
+++ b/app/controllers/customers/orders_controller.rb
@@ -59,6 +59,7 @@ class Customers::OrdersController < ApplicationController
 
   def index
     @orders = @customer.orders
+    binding.pry
   end
 
   def show

--- a/app/controllers/customers/products_controller.rb
+++ b/app/controllers/customers/products_controller.rb
@@ -26,8 +26,13 @@ class Customers::ProductsController < ApplicationController
   end
 
   def name_search
+
+    if params[:category_id]==""
+      category=Product.all
+    elsif
     category=Product.where(category_id: params[:category_id])
-    product=category.where(['name LIKE?',"%#{params[:seach]}%"])
+    end
+    product=category.where(['name LIKE?',"%#{params[:search]}%"])
     @products=product.page(params[:page]).per(8)
     @quantity=product.count
     @categories=Category.where(is_effective: "true" )

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,7 +2,8 @@ class Order < ApplicationRecord
   belongs_to :customer
   has_many :order_products, dependent: :destroy
 
-  has_many :products
+  has_many :products, :through => :order_products
+  accepts_nested_attributes_for :order_products
 
 
   validates :address, presence: true, length: {maximum: 35, minimum: 2}

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,8 +2,8 @@ class Order < ApplicationRecord
   belongs_to :customer
   has_many :order_products, dependent: :destroy
 
-  has_many :products, :through => :order_products
-  accepts_nested_attributes_for :order_products
+  has_many :products
+
 
   validates :address, presence: true, length: {maximum: 35, minimum: 2}
   validates :postal_code, presence: true, length: {maximum: 10, minimum: 2}

--- a/app/views/admins/homes/home.html.erb
+++ b/app/views/admins/homes/home.html.erb
@@ -6,7 +6,6 @@
       <div class='col-lg-12'>
         <h3>本日の注文件数　　<a><%= @todays_order %></a>
         件</h3>
-        <%= link_to "ログアウト", destroy_admin_session_path, method: :delete %>
       </div>
     </div>
 </div>

--- a/app/views/admins/orders/index.html.erb
+++ b/app/views/admins/orders/index.html.erb
@@ -21,7 +21,7 @@
               <td>
                 <%= order.id %>
               </td>
-              <td><%= order.created_at.strftime('%Y/%m/%d %H:%M:%S') %></td>
+              <td><%= order.created_at.to_s(:datetime_jp) %></td>
               <td>
                 <!-- 詳細へリンク -->
                 <%= link_to order.customer.first_name + order.customer.last_name, admins_order_path(order) %>

--- a/app/views/admins/orders/show.html.erb
+++ b/app/views/admins/orders/show.html.erb
@@ -27,6 +27,7 @@
           </tbody>
         </table>
       </div>
+      <% end %>
       <div class="col-lg-9">
         <table class="table" style="width: 800px">
           <thead>
@@ -39,17 +40,19 @@
             </tr>
           </thead>
           <tbody>
-            <%= f.fields_for :order_products do |i| %>
+            <% @product.each do |product| %>
+            <%= form_for product,url:admins_order_product_update_path(product),method: :patch do |f| %>
               <tr>
-                  <td><%= product = Product.find(i.object.product_id).name %></td>
-                  <td><%= i.object.price_with_tax %></td>
-                  <td><%= i.object.quantity %></td>
-                  <td><%= i.object.price_with_tax * i.object.quantity %></td>
+                  <td><%= Product.find(product.product_id).name %></td>
+                  <td><%= product.price_with_tax %></td>
+                  <td><%= product.quantity %></td>
+                  <td><%= product.price_with_tax * product.quantity %></td>
                   <td>
-                    <%= i.select :product_status, OrderProduct.product_statuses.keys.map {|l| [I18n.t("enums.order_product.product_status.#{l}"), l]}  %>
+                    <%= f.select :product_status, OrderProduct.product_statuses.keys.map {|k| [I18n.t("enums.order_product.product_status.#{k}"), k]}  %>
                     <%= f.submit '更新', class: 'btn btn-primary btn-xs' %>
                   </td>
               </tr>
+              <% end %>
             <% end %>
           </tbody>
         </table>
@@ -63,7 +66,7 @@
           <tbody>
             <% sum_all = 0 %>
             <% @order.order_products.each do |order_product| %>
-              <% sum_all += order_product.price_with_tax %>
+              <% sum_all += order_product.price_with_tax*order_product.quantity %>
             <% end %>
             <tr>
               <td style="border: none;"><strong>商品合計</strong></td>
@@ -80,6 +83,5 @@
           </tbody>
         </table>
       </div>
-    <% end %>
   </div>
 </div>

--- a/app/views/customers/customers/show.html.erb
+++ b/app/views/customers/customers/show.html.erb
@@ -53,7 +53,7 @@
         <h4><strong>注文履歴</strong></h4>
       </div>
       <div class="col-sm-1" style="">
-        <%= link_to '一覧を見る', "orders_path", class: 'btn btn-primary' %>
+        <%= link_to '一覧を見る', orders_path, class: 'btn btn-primary' %>
       </div>
     </div>
 </div>

--- a/app/views/customers/homes/top.html.erb
+++ b/app/views/customers/homes/top.html.erb
@@ -38,7 +38,7 @@
           <% @products.each do |product| %>
             <div class="box" style="float:left; margin-right:0px;">
               <%= link_to product_path(product.id) do %>
-                <%= attachment_image_tag product, :image, :fill, 182, 110, format: 'jpeg', fallback: 'no_image.png' %>
+                <%= attachment_image_tag product, :image, :fill, 182, 110, format: 'jpeg', fallback: 'no_image.png',size:'200x100'%>
               <% end %>
 　　　        <p class="catecoriesname"><strong><%= product.name %><br>¥<%= product.price %></strong></p>
 

--- a/app/views/customers/orders/new.html.erb
+++ b/app/views/customers/orders/new.html.erb
@@ -1,5 +1,6 @@
 <!-- Bootstrapのclass  要調整 -->
 <div class=" container ">
+  <h2 class="text-danger bg-warning"><%= flash[:danger] %></h2>
   <div class="row">
     <div class="col-lg-4">
       <h4><mark style="background-color: #F8F8F8F8;">注文情報入力</mark></h4>
@@ -50,7 +51,7 @@
         </label><br>
         <!-- プルダウン機能 :send_to_address→confirm actionへparamを渡す -->
         <!-- :select_destはorder.rbでカラムを結合したメソッド -->
-        <%= f.collection_select :send_to_address, @customer.destinations, :id, :full_dest %>
+        <%= f.collection_select :send_to_address, @customer.destinations, :id, :full_dest,prompt:"--住所を選択してください--" %>
       </p>
     </div>
     <!-- 新しい配送先 -->

--- a/app/views/customers/products/index.html.erb
+++ b/app/views/customers/products/index.html.erb
@@ -28,7 +28,7 @@
       <% @products.each do |product| %>
         <div class="box" style="float: left; margin-right: 0px; padding-top: 50px;">
           <%= link_to product_path(product.id) do %>
-            <%= attachment_image_tag product, :image, :fill, 200, 100, format: 'jpeg', fallback: 'no_image.png' %>
+            <%= attachment_image_tag product, :image, :fill, 200, 100, format: 'jpeg', fallback: 'no_image.png', size:'200x100' %>
           <% end %>
 　　　　   <p><strong><%= product.name %></strong></p>
 　　　　   <p><strong>¥<%= product.price %></strong></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
               <li><%= link_to 'ログアウト', destroy_customer_session_path, method: :delete, class: '' %></li>
               <div class="seach-window pull-bottom">
                 <%= form_with url:name_search_path,:method => 'get',local: true,skip_enforcing_utf8: true do |f| %>
-                  <%= f.collection_select(:category_id,Category.where(is_effective: "true" ),:id,:name) %>
+                  <%= f.collection_select(:category_id,Category.where(is_effective: "true" ),:id,:name,prompt:"ジャンル選択") %>
                   <%= f.text_field :search %>
                   <%= f.submit '検索',name: nil %>
                 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module Naganocake
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:datetime_jp] = '%Y年 %m月 %d日 %H時 %M分'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -214,7 +214,7 @@ ja:
         Waiting_for_payment: 入金待ち
         Payment_confirmation: 入金確認
         In_production: 制作中
-        Ready_to_ship: 発注準備中
+        Ready_to_ship: 発送準備中
         Sent: 発送済み
     order_product:
       product_status:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
     resources :categories, only: [:index, :edit, :create, :update]
     resources :order_products, only: [:update]
     get 'home' => "homes#home", as: 'home'
+    patch 'order_product/:id' => "order_products#update",as: 'order_product_update'
   end
 
 end


### PR DESCRIPTION
不具合の修正
・製作ステータスと注文商品ステータスを連動
・注文データが保存されない不具合を修正→情報入力画面で不備がある場合に最入力画面へ遷移
・アプリ内の時間を標準時から日本時間に修正
・注文商品情報の税込価格の計算時に浮動小数の切り捨て処理を追加
・カートが空の際に情報入力画面に遷移しないように修正
・注文情報入力画面で、プルダウンメニューにデフォルトメッセージを追加
・発注準備中→発送準備中に修正